### PR TITLE
fixed coupon code filtering

### DIFF
--- a/discount/models.py
+++ b/discount/models.py
@@ -128,6 +128,6 @@ class CartDiscountCode(models.Model):
 
     def clean_fields(self, *args, **kwargs):
         super(CartDiscountCode, self).clean_fields(*args, **kwargs)
-        if not DiscountBase.objects.active().filter(code=self.code):
+        if not DiscountBase.objects.active(code=self.code):
             msg = _('Discount code is invalid or expired.')
             raise ValidationError({'code': [msg]})


### PR DESCRIPTION
The code for validating a coupon code was creating a SQL query that was something like this:

``` sql
SELECT ... AND (`discount_discountbase`.`code` = '' OR `discount_discountbase`.`code` = '' ) AND `discount_discountbase`.`code` = 'codename' )
```

A coupon code can never be both `''` and `'codename'` so the model was never valid.
