### PR TITLE
quantized percent discount return value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 docs/_build
 database.db
 dist/
+*.egg-info/

--- a/discount/mixins.py
+++ b/discount/mixins.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
@@ -9,7 +11,7 @@ class PercentDiscountMixin(models.Model):
     amount = models.DecimalField(_('Amount'), max_digits=5, decimal_places=2)
 
     def get_extra_cart_price_field(self, cart):
-        amount = (self.amount/100) * cart.subtotal_price
+        amount = ((self.amount / 100) * cart.subtotal_price).quantize(Decimal('1.00'))
         return (self.get_name(), amount,)
 
     class Meta:


### PR DESCRIPTION
The Cart Modifier was adding discounts that looked like 1.5454, so I made it return a two decimal place number instead.

I don't know if the other mixins need this too or not as I am not using them.
