### PR TITLE
Fix for issue #15: fixed url import for django 1.6+

### DIFF
--- a/discount/urls.py
+++ b/discount/urls.py
@@ -1,9 +1,9 @@
 try:
     # django 1.6+
-    from django.conf.urls import patterns
+    from django.conf.urls import patterns,url
 except ImportError:
     # django <1.6
-    from django.conf.urls.defaults import patterns
+    from django.conf.urls.defaults import patterns,url
 
 
 from discount.views import CartDiscountCodeDeleteView, CartDiscountCodeCreateView

--- a/discount/urls.py
+++ b/discount/urls.py
@@ -1,4 +1,10 @@
-from django.conf.urls.defaults import url, patterns
+try:
+    # django 1.6+
+    from django.conf.urls import patterns
+except ImportError:
+    # django <1.6
+    from django.conf.urls.defaults import patterns
+
 
 from discount.views import CartDiscountCodeDeleteView, CartDiscountCodeCreateView
 


### PR DESCRIPTION
This is to address the import issue for issue 15.  This should work with both django 1.4 and 1.6
